### PR TITLE
fix: changed the import statements

### DIFF
--- a/src/components/controllers/ChainTxHandler.tsx
+++ b/src/components/controllers/ChainTxHandler.tsx
@@ -10,7 +10,7 @@ import {
     TxWaiter,
 } from "@renproject/utils";
 
-import { RenVMCrossChainTxSubmitter } from "../../../../ren-js-v3/packages/ren/build/main/renVMTxSubmitter";
+import { RenVMCrossChainTxSubmitter } from "@renproject/ren/build/main/renVMTxSubmitter";
 import { RenState } from "../../state/renState";
 import { Spinner } from "../views/Spinner";
 

--- a/src/components/controllers/CurrentGateway.tsx
+++ b/src/components/controllers/CurrentGateway.tsx
@@ -5,7 +5,7 @@ import { CheckIcon, XIcon } from "@heroicons/react/solid";
 import { Gateway } from "@renproject/ren";
 import { ChainTransactionStatus } from "@renproject/utils";
 
-import { Ethereum } from "../../../../ren-js-v3/packages/chains/chains-ethereum/build/main";
+import { Ethereum } from "@renproject/chains-ethereum/build/main";
 import GatewaySummary from "../views/GatewaySummary";
 import { Spinner } from "../views/Spinner";
 import ViewDepositGateway from "../views/ViewDepositGateway";

--- a/src/state/renState.tsx
+++ b/src/state/renState.tsx
@@ -5,7 +5,7 @@ import { createContainer } from "unstated-next";
 
 import RenJS, { GatewayTransaction } from "@renproject/ren";
 
-import { TransactionParams } from "../../../ren-js-v3/packages/ren/build/main/gatewayTransaction";
+import { TransactionParams } from "@renproject/ren/build/main/gatewayTransaction";
 import { NETWORK } from "../lib/constants";
 import { defaultChains } from "../lib/renJS";
 


### PR DESCRIPTION
If you try to build the repo on a windows 10 machine, you'll get a "module not found" error, with the old import statements. I updated them to point to the installed renproject modules folder